### PR TITLE
Fix 404 content type

### DIFF
--- a/src/clothesline/request_handler.clj
+++ b/src/clothesline/request_handler.clj
@@ -20,7 +20,7 @@
 (defn no-handler-found [req]
   "Returns a 404 when no appropriate handler was found"
   (-> (response "404 - Resource Not found")
-      (content-type "text-plain")
+      (content-type "text/plain")
       (status 404)))
 
 (defn- match-route [req route handler]

--- a/test/clothesline/test/request_handler.clj
+++ b/test/clothesline/test/request_handler.clj
@@ -1,0 +1,10 @@
+(ns clothesline.test.request-handler
+  (:use clojure.test)
+  (:require [clothesline.request-handler :as rh]
+            [clothesline.test.test-helpers :as test]))
+
+(deftest no-handler-found
+  (let [response (rh/no-handler-found (test/make-request))]
+    (is (= 404 (:status response)))
+    ;; this was broken, so enforce a legal content-type.
+    (is (re-find #"^[^/]+/[^/]+$" (get-in response [:headers "Content-Type"])))))


### PR DESCRIPTION
The returned content type had a - rather than /, which wasn't strictly legal,
albeit probably not notable what with the defaulting to plain text and all.

Also, add tests to ensure that we don't regress on the failure.

Signed-off-by: Daniel Pittman daniel@rimspace.net
