### PR TITLE
Add defhandler

### DIFF
--- a/src/clothesline/service/helpers.clj
+++ b/src/clothesline/service/helpers.clj
@@ -1,8 +1,12 @@
 (ns clothesline.service.helpers
   (:require [clothesline.service :as service]))
 
-
-(def ^{:arglists '([type map-of-fns] [type & kw-and-impls]) :name "extend-as-handler"}
+(def
+  ^{:name "extend-as-handler"
+    :arglists '([type map-of-fns] [type & kw-and-impls])
+    :doc "Extend an existing type with the service behaviours to become a
+Clothesline resource.  This merges the supplied behaviours with the default
+set of behaviours required to work correctly."}
      extend-as-handler
      (fn  [type & params]
        (if (and (map? (first params))
@@ -11,13 +15,36 @@
          (extend type service/service (merge service/service-default (apply hash-map params))))))
 
 
-(defmacro defsimplehandler [name & ct-generator-forms]
+(defmacro defhandler
+  "Define a new Clothesline handler type and instance, extending the default
+behaviour with custom handlers by mapping symbols to service implementations.
+
+See `clothesline.service/service` or WebMachine for available methods,
+including their arguments and return values.
+
+See `extend-as-handler` for full details of the valid body forms.
+
+    (defhandler example {:service-available? (constantly false)})
+
+    ;; (defn sample-malformed-request [...] ...)
+    (defhandler sample
+      :allowed-methods     (constantly #{:head :get})
+      :malformed-request?  sample-malformed-request?
+      :resource-exists? (fn [...] ...))"
+  {:arglists '([name map-of-fns] [name & kw-and-impls])}
+  [name & params]
   (let [typename (symbol (str name "-type"))]
     `(do
+       ;; Define a type to hook into the protocol mechanism.
        (deftype ~typename [])
-       (extend ~typename service/service
-               (merge service/service-default
-                      {:content-types-provided
-                       (fn [handler# request# graphdata#] (hash-map ~@ct-generator-forms))
-                       :allowed-methods (constantly #{:get :head :post :options :put})}))
+       ;; Extend that with the standard suite of behaviours...
+       (clothesline.service.helpers/extend-as-handler ~typename ~@params)
+       ;; ...and a user accessor.
        (def ~name (new ~typename)))))
+
+
+(defmacro defsimplehandler [name & ct-generator-forms]
+  `(clothesline.service.helpers/defhandler ~name
+     :allowed-methods (constantly #{:get :head :post :put :delete :options})
+     :content-types-provided (fn [handler# request# graphdata#]
+                               (hash-map ~@ct-generator-forms))))

--- a/test/clothesline/complex_server.clj
+++ b/test/clothesline/complex_server.clj
@@ -14,49 +14,39 @@
 
 
 ;; Behavior
-(def behavior
-     {:allowed-methods (fn [_ _ _]
-                         (test/annotated-return #{:get :post :put}
-                                                {:annotate {:debug-output
-                                                            (fn [_] (println "o/~"))}}))
-      
-      :malformed-request? (fn [_ {:keys [request-method params]} _]
-                            (let [name (params "name")
-                                  location (params "location")]
-                              (cond
-                               (= request-method :get) (nil? name)
-                               :otherwise              (or (nil? name)
-                                                           (nil? location)))))
-      :previously-existed? (fn [_ {params :params} _] (get-name-url (params "name")))
-      :resource-exists? (constantly false)
-      :allow-missing-post? (constantly true)
-      :moved-permanently? (fn [_ {params :params method :request-method} _]
-                            
-                            (if (= method :put)
-                              false
-                              (get-name-url (params "name"))))
-      :post-is-create? (fn [_ {params :params} _] (not (name-exists? (params "name"))))
-      :create-path (fn [_ {{:strs [name]} :params} _] (test/annotated-return (str "/" name)))
-      :process-post (fn [_ {{:strs [name location]} :params :as request} _]
-                         (add-name-url name location)
-                         (test/annotated-return true))
+(helpers/defhandler bookmark-handler
+  :allowed-methods (fn [_ _ _]
+                     (test/annotated-return #{:get :post :put}
+                                            {:annotate {:debug-output
+                                                        (fn [_] (println "o/~"))}}))
+  :malformed-request? (fn [_ {:keys [request-method params]} _]
+                        (let [name (params "name")
+                              location (params "location")]
+                          (cond
+                           (= request-method :get) (nil? name)
+                           :otherwise              (or (nil? name)
+                                                       (nil? location)))))
+  :previously-existed? (fn [_ {params :params} _] (get-name-url (params "name")))
+  :resource-exists?    (constantly false)
+  :allow-missing-post? (constantly true)
+  :moved-permanently?  (fn [_ {params :params method :request-method} _]
+                         (if (= method :put)
+                           false
+                           (get-name-url (params "name"))))
+  :post-is-create? (fn [_ {params :params} _] (not (name-exists? (params "name"))))
+  :create-path (fn [_ {{:strs [name]} :params} _] (test/annotated-return (str "/" name)))
+  :process-post (fn [_ {{:strs [name location]} :params :as request} _]
+                  (add-name-url name location)
+                  (test/annotated-return true))
 
-      ;; This is mostly just to handle params
-      :content-types-accepted (fn [& _]
-                                {"*/*" (fn [{params :params body :body} _]
-                                         (add-name-url (params "name")
-                                                       (params "location")))})
-     }
-
-)
-
-(defrecord bookmark-handler [])
-(helpers/extend-as-handler bookmark-handler behavior)
+  ;; This is mostly just to handle params
+  :content-types-accepted (fn [& _]
+                            {"*/*" (fn [{params :params body :body} _]
+                                     (add-name-url (params "name")
+                                                   (params "location")))}))
 
 ;; Server
-
-
-(defonce *server* (delay (clothesline.core/produce-server {"/:name" (bookmark-handler.)} 
-                                                          {:join? false :port 9001})))
-
-
+(defonce *server*
+  (delay (clothesline.core/produce-server
+          {"/:name" bookmark-handler}
+          {:join? false :port 9001})))


### PR DESCRIPTION
`defhandler` wraps the complexity of building a handler, together with default
behaviour, in a simple macro that expands, more or less, to define a type,
augment the default behaviours with the supplied behaviours, and then
creates a ready-to-use instance for the user.

`defsimplehandler` is reimplemented in terms of `defhandler`, and the complex
server test is also implemented using the wrapper macro.

Finally, update the documentation to reflect these changes.

Signed-off-by: Daniel Pittman daniel@rimspace.net
