### PR TITLE
Fix failing test

### DIFF
--- a/test/clothesline/test/syntax.clj
+++ b/test/clothesline/test/syntax.clj
@@ -55,7 +55,7 @@
         map* {"*/*"       k1}]
     (is (= ["text/html" k1] (t-helpers/map-accept-header def-request-xml "accept" map1)))
     (is (nil? (t-helpers/map-accept-header def-request-crd "accept" map1 false)))
-    (is (= ["text/html" k1] (t-helpers/map-accept-header def-request-crd "accept" map1)))
+    (is (nil? (t-helpers/map-accept-header def-request-crd "accept" map1)))
     (is (= ["text/html" k1] (t-helpers/map-accept-header def-request-html "accept" map2)))
     (is (= ["text/xml" k2] (t-helpers/map-accept-header def-request-xml "accept" map2)))
     (is (= ["*/*"      k1] (t-helpers/map-accept-header def-request-xml "accept" map*)))))


### PR DESCRIPTION
When handling of the accept header was defaulted to nil, rather than the first
content type, the tests were not fully updated to reflect the change.

Now, as expected, an accept header that does not match any provided content
type will result in no valid response and, consequently, an error back to the
client.

This correctly mirrors WebMachine behaviour.

Signed-off-by: Daniel Pittman daniel@rimspace.net
